### PR TITLE
#36 Add Tests for controllers.

### DIFF
--- a/src/test/java/org/example/springboot_labb2/controller/MessageControllerTest.java
+++ b/src/test/java/org/example/springboot_labb2/controller/MessageControllerTest.java
@@ -1,0 +1,183 @@
+package org.example.springboot_labb2.controller;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.hamcrest.Matchers.*;
+
+
+import static org.mockito.ArgumentMatchers.any;
+import org.example.springboot_labb2.entity.Message;
+import org.example.springboot_labb2.exception.ResourceNotFoundException;
+import org.example.springboot_labb2.repository.MessageRepository;
+import org.example.springboot_labb2.service.MessageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+public class MessageControllerTest {
+
+    @InjectMocks
+    private MessageService messageService;
+    private MockMvc mockMvc;
+
+    @Mock
+    private MessageRepository messageRepository;
+
+    @InjectMocks
+    private MessageController messageController;
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.standaloneSetup(messageController)
+                .build();
+    }
+
+    @Test
+    public void getAllMessages_ShouldReturnMessageList() throws Exception {
+        when(messageRepository.findAll()).thenReturn(Arrays.asList(new Message(), new Message()));
+
+        mockMvc.perform(get("/api/messages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)));
+    }
+
+    @Test
+    public void getMessageById_WhenMessageExists_ShouldReturnMessage() throws Exception {
+        Long messageId = 1L;
+        Message message = new Message();
+        message.setId(messageId);
+        when(messageRepository.findById(messageId)).thenReturn(Optional.of(message));
+
+        mockMvc.perform(get("/api/messages/{id}", messageId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(messageId.intValue())));
+    }
+
+    @Test
+    public void getMessageById_WhenMessageDoesNotExist_ShouldReturnNotFound() throws Exception {
+        Long messageId = 1L;
+        when(messageRepository.findById(messageId)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/messages/{id}", messageId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void updateMessage_NonExistingId_ShouldThrowException() {
+        Long nonExistingId = 99L;
+        Message updateInfo = new Message();
+        updateInfo.setTitle("Updated Title");
+        updateInfo.setContent("Updated content");
+        when(messageRepository.existsById(nonExistingId)).thenReturn(false);
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            messageService.updateMessage(nonExistingId, updateInfo);
+        });
+    }
+
+    @Test
+    void deleteMessage_NonExistingId_ShouldReturnNotFound() throws Exception {
+        Long nonExistingId = 99L;
+        when(messageRepository.existsById(nonExistingId)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/messages/{id}", nonExistingId))
+                .andExpect(status().isNotFound());
+    }
+
+
+    @Test
+    public void whenCreateMessage_thenStatus201() throws Exception {
+        Message newMessage = new Message();
+        newMessage.setTitle("New Title");
+        newMessage.setContent("New Content");
+
+        when(messageService.createMessage(any(Message.class))).thenReturn(newMessage);
+
+        mockMvc.perform(post("/api/messages")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(newMessage)))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
+                .andExpect(jsonPath("$.title", is(newMessage.getTitle())))
+                .andExpect(jsonPath("$.content", is(newMessage.getContent())));
+    }
+
+    public static String asJsonString(final Object obj) {
+        try {
+            return new ObjectMapper().writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void givenMessageToUpdate_whenMessageExists_thenStatus200() throws Exception {
+        Long existingId = 1L;
+        Message existingMessage = new Message();
+        existingMessage.setId(existingId);
+        existingMessage.setTitle("Existing Title");
+        existingMessage.setContent("Existing content");
+
+        when(messageRepository.existsById(existingId)).thenReturn(true);
+        when(messageRepository.save(any(Message.class))).thenReturn(existingMessage);
+
+        mockMvc.perform(put("/api/messages/{id}", existingId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(existingMessage)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(existingId.intValue())))
+                .andExpect(jsonPath("$.title", is(existingMessage.getTitle())))
+                .andExpect(jsonPath("$.content", is(existingMessage.getContent())));
+    }
+
+    @Test
+    public void givenMessageToUpdate_whenMessageDoesNotExist_thenStatus404() throws Exception {
+        Long nonExistingId = 2L;
+        Message updatedMessage = new Message();
+        updatedMessage.setTitle("Updated Title");
+        updatedMessage.setContent("Updated Content");
+
+        when(messageRepository.existsById(nonExistingId)).thenReturn(false);
+
+        mockMvc.perform(put("/api/messages/{id}", nonExistingId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(updatedMessage)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void givenMessageIdToDelete_whenMessageExists_thenStatus204() throws Exception {
+        Long existingId = 1L;
+
+        when(messageRepository.existsById(existingId)).thenReturn(true);
+        doNothing().when(messageRepository).deleteById(existingId);
+
+        mockMvc.perform(delete("/api/messages/{id}", existingId))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void givenMessageIdToDelete_whenMessageDoesNotExist_thenStatus404() throws Exception {
+        Long nonExistingId = 2L;
+
+        when(messageRepository.existsById(nonExistingId)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/messages/{id}", nonExistingId))
+                .andExpect(status().isNotFound());
+    }
+
+
+}

--- a/src/test/java/org/example/springboot_labb2/controller/MessageControllerTest.java
+++ b/src/test/java/org/example/springboot_labb2/controller/MessageControllerTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.*;
 
 
 import static org.mockito.ArgumentMatchers.any;
+
 import org.example.springboot_labb2.entity.Message;
 import org.example.springboot_labb2.exception.ResourceNotFoundException;
 import org.example.springboot_labb2.repository.MessageRepository;
@@ -46,7 +47,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void getAllMessages_ShouldReturnMessageList() throws Exception {
+    void getAllMessages_ShouldReturnMessageList() throws Exception {
         when(messageRepository.findAll()).thenReturn(Arrays.asList(new Message(), new Message()));
 
         mockMvc.perform(get("/api/messages"))
@@ -55,7 +56,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void getMessageById_WhenMessageExists_ShouldReturnMessage() throws Exception {
+    void getMessageById_WhenMessageExists_ShouldReturnMessage() throws Exception {
         Long messageId = 1L;
         Message message = new Message();
         message.setId(messageId);
@@ -67,7 +68,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void getMessageById_WhenMessageDoesNotExist_ShouldReturnNotFound() throws Exception {
+    void getMessageById_WhenMessageDoesNotExist_ShouldReturnNotFound() throws Exception {
         Long messageId = 1L;
         when(messageRepository.findById(messageId)).thenReturn(Optional.empty());
 
@@ -99,7 +100,7 @@ public class MessageControllerTest {
 
 
     @Test
-    public void whenCreateMessage_thenStatus201() throws Exception {
+    void whenCreateMessage_thenStatus201() throws Exception {
         Message newMessage = new Message();
         newMessage.setTitle("New Title");
         newMessage.setContent("New Content");
@@ -124,7 +125,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void givenMessageToUpdate_whenMessageExists_thenStatus200() throws Exception {
+    void givenMessageToUpdate_whenMessageExists_thenStatus200() throws Exception {
         Long existingId = 1L;
         Message existingMessage = new Message();
         existingMessage.setId(existingId);
@@ -144,7 +145,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void givenMessageToUpdate_whenMessageDoesNotExist_thenStatus404() throws Exception {
+    void givenMessageToUpdate_whenMessageDoesNotExist_thenStatus404() throws Exception {
         Long nonExistingId = 2L;
         Message updatedMessage = new Message();
         updatedMessage.setTitle("Updated Title");
@@ -159,7 +160,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void givenMessageIdToDelete_whenMessageExists_thenStatus204() throws Exception {
+    void givenMessageIdToDelete_whenMessageExists_thenStatus204() throws Exception {
         Long existingId = 1L;
 
         when(messageRepository.existsById(existingId)).thenReturn(true);
@@ -170,7 +171,7 @@ public class MessageControllerTest {
     }
 
     @Test
-    public void givenMessageIdToDelete_whenMessageDoesNotExist_thenStatus404() throws Exception {
+    void givenMessageIdToDelete_whenMessageDoesNotExist_thenStatus404() throws Exception {
         Long nonExistingId = 2L;
 
         when(messageRepository.existsById(nonExistingId)).thenReturn(false);

--- a/src/test/java/org/example/springboot_labb2/controller/RegistrationControllerTest.java
+++ b/src/test/java/org/example/springboot_labb2/controller/RegistrationControllerTest.java
@@ -1,0 +1,55 @@
+package org.example.springboot_labb2.controller;
+
+import org.example.springboot_labb2.entity.User;
+import org.example.springboot_labb2.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@ExtendWith(MockitoExtension.class)
+public class RegistrationControllerTest {
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private RegistrationController registrationController;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(registrationController).build();
+    }
+
+    @Test
+    public void showRegistrationForm_ShouldReturnRegistrationView() throws Exception {
+        mockMvc.perform(get("/register"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("registration"));
+    }
+
+    @Test
+    public void registerUser_ShouldSaveUserAndRedirectToLogin() throws Exception {
+        mockMvc.perform(post("/register")
+                        .param("username", "newUser")
+                        .param("nameSurname", "New User")
+                        .param("email", "newuser@example.com")
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/login"));
+
+        verify(userRepository).save(any(User.class));
+    }
+}

--- a/src/test/java/org/example/springboot_labb2/controller/RegistrationControllerTest.java
+++ b/src/test/java/org/example/springboot_labb2/controller/RegistrationControllerTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -18,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 @ExtendWith(MockitoExtension.class)
-public class RegistrationControllerTest {
+class RegistrationControllerTest {
 
     private MockMvc mockMvc;
 
@@ -34,14 +35,14 @@ public class RegistrationControllerTest {
     }
 
     @Test
-    public void showRegistrationForm_ShouldReturnRegistrationView() throws Exception {
+    void showRegistrationForm_ShouldReturnRegistrationView() throws Exception {
         mockMvc.perform(get("/register"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("registration"));
     }
 
     @Test
-    public void registerUser_ShouldSaveUserAndRedirectToLogin() throws Exception {
+    void registerUser_ShouldSaveUserAndRedirectToLogin() throws Exception {
         mockMvc.perform(post("/register")
                         .param("username", "newUser")
                         .param("nameSurname", "New User")

--- a/src/test/java/org/example/springboot_labb2/controller/UserControllerTest.java
+++ b/src/test/java/org/example/springboot_labb2/controller/UserControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
 import static org.hamcrest.Matchers.*;
 
 import java.util.Arrays;
@@ -23,7 +24,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @ExtendWith(MockitoExtension.class)
-public class UserControllerTest {
+class UserControllerTest {
 
     @Mock
     private UserRepository userRepository;
@@ -39,7 +40,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void getAllUsers_ShouldReturnUserList() throws Exception {
+    void getAllUsers_ShouldReturnUserList() throws Exception {
         when(userRepository.findAll()).thenReturn(Arrays.asList(new User(), new User()));
 
         mockMvc.perform(get("/api/users"))
@@ -48,7 +49,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void getUserById_WhenUserExists_ShouldReturnUser() throws Exception {
+    void getUserById_WhenUserExists_ShouldReturnUser() throws Exception {
         Long userId = 1L;
         User user = new User();
         user.setId(userId);
@@ -60,7 +61,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void getUserById_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
+    void getUserById_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
         Long userId = 1L;
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
@@ -69,7 +70,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void createUser_ShouldCreateUserAndReturnCreatedUser() throws Exception {
+    void createUser_ShouldCreateUserAndReturnCreatedUser() throws Exception {
         User user = new User();
         user.setUsername("newUser");
         when(userRepository.save(any(User.class))).thenReturn(user);
@@ -83,7 +84,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void updateUser_WhenUserExists_ShouldUpdateUserAndReturnIt() throws Exception {
+    void updateUser_WhenUserExists_ShouldUpdateUserAndReturnIt() throws Exception {
         Long userId = 1L;
         User existingUser = new User();
         existingUser.setId(userId);
@@ -99,7 +100,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void updateUser_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
+    void updateUser_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
         Long userId = 1L;
         User updateUser = new User();
         updateUser.setUsername("nonExistentUser");
@@ -112,7 +113,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void deleteUser_WhenUserExists_ShouldDeleteUserAndReturnNoContent() throws Exception {
+    void deleteUser_WhenUserExists_ShouldDeleteUserAndReturnNoContent() throws Exception {
         Long userId = 1L;
         when(userRepository.existsById(userId)).thenReturn(true);
         doNothing().when(userRepository).deleteById(userId);
@@ -122,7 +123,7 @@ public class UserControllerTest {
     }
 
     @Test
-    public void deleteUser_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
+    void deleteUser_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
         Long userId = 1L;
         when(userRepository.existsById(userId)).thenReturn(false);
 

--- a/src/test/java/org/example/springboot_labb2/controller/UserControllerTest.java
+++ b/src/test/java/org/example/springboot_labb2/controller/UserControllerTest.java
@@ -1,0 +1,140 @@
+package org.example.springboot_labb2.controller;
+
+import org.example.springboot_labb2.entity.User;
+import org.example.springboot_labb2.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserControllerTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserController userController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(userController).build();
+    }
+
+    @Test
+    public void getAllUsers_ShouldReturnUserList() throws Exception {
+        when(userRepository.findAll()).thenReturn(Arrays.asList(new User(), new User()));
+
+        mockMvc.perform(get("/api/users"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)));
+    }
+
+    @Test
+    public void getUserById_WhenUserExists_ShouldReturnUser() throws Exception {
+        Long userId = 1L;
+        User user = new User();
+        user.setId(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/api/users/{id}", userId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(userId.intValue())));
+    }
+
+    @Test
+    public void getUserById_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
+        Long userId = 1L;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/users/{id}", userId))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void createUser_ShouldCreateUserAndReturnCreatedUser() throws Exception {
+        User user = new User();
+        user.setUsername("newUser");
+        when(userRepository.save(any(User.class))).thenReturn(user);
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(user)))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"))
+                .andExpect(jsonPath("$.username", is(user.getUsername())));
+    }
+
+    @Test
+    public void updateUser_WhenUserExists_ShouldUpdateUserAndReturnIt() throws Exception {
+        Long userId = 1L;
+        User existingUser = new User();
+        existingUser.setId(userId);
+        existingUser.setUsername("updatedUser");
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(userRepository.save(any(User.class))).thenReturn(existingUser);
+
+        mockMvc.perform(put("/api/users/{id}", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(existingUser)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username", is(existingUser.getUsername())));
+    }
+
+    @Test
+    public void updateUser_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
+        Long userId = 1L;
+        User updateUser = new User();
+        updateUser.setUsername("nonExistentUser");
+        when(userRepository.existsById(userId)).thenReturn(false);
+
+        mockMvc.perform(put("/api/users/{id}", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(updateUser)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void deleteUser_WhenUserExists_ShouldDeleteUserAndReturnNoContent() throws Exception {
+        Long userId = 1L;
+        when(userRepository.existsById(userId)).thenReturn(true);
+        doNothing().when(userRepository).deleteById(userId);
+
+        mockMvc.perform(delete("/api/users/{id}", userId))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void deleteUser_WhenUserDoesNotExist_ShouldReturnNotFound() throws Exception {
+        Long userId = 1L;
+        when(userRepository.existsById(userId)).thenReturn(false);
+
+        mockMvc.perform(delete("/api/users/{id}", userId))
+                .andExpect(status().isNotFound());
+    }
+
+    private String asJsonString(final Object obj) {
+        try {
+            return new ObjectMapper().writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
I've added Tests for controllers with full coverage except for WebController (this will need to be added later on). The tests in general will also need updating as the application progresses, for example it has full coverage but this is not covered as of now:

    @PatchMapping("/messages/{id}/privacy")
    public ResponseEntity<Message> updateMessagePrivacy(@PathVariable Long id, @RequestParam boolean isPrivate) {
        Message updatedMessage = messageService.updateMessageStatus(id, isPrivate);
        return ResponseEntity.ok(updatedMessage);
    }
    
    Other than this part, the tests have full coverage.